### PR TITLE
Include external CSS in SWC lessons

### DIFF
--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -61,7 +61,10 @@ def download_lessons(ods_dir):
                   "https://datacarpentry.org/R-ecology-lesson/",
                   "https://datacarpentry.org/python-ecology-lesson/",
                   "https://datacarpentry.org/sql-ecology-lesson/"]
-    
+
+    for lesson in dc_lessons:
+        subprocess.run(["wget", "-r", "-k", "-N", "-c", "--no-parent", "-P", ods_dir, lesson])
+
     sc_lessons = ["http://swcarpentry.github.io/shell-novice",
                   "http://swcarpentry.github.io/git-novice",
                   "http://swcarpentry.github.io/python-novice-inflammation",
@@ -72,9 +75,9 @@ def download_lessons(ods_dir):
                   "http://swcarpentry.github.io/git-novice-es",
                   "http://swcarpentry.github.io/r-novice-gapminder-es"]
 
-    lessons = dc_lessons + sc_lessons
-    for lesson in lessons:
-        subprocess.run(["wget", "-r", "-k", "-N", "-c", "--no-parent", "-P", ods_dir, lesson])
+    # Software Carpentry lessons have external CSS so requires a more expansize search & rewriting to get all necessary files
+    for lesson in sc_lessons:
+        subprocess.run(["wget", "-p", "-r", "-k", "-N", "-c", "-E", "-H", "-D", "swcarpentry.github.io", "-K", "--no-parent", "-P", ods_dir, lesson])
 
 def download_software(ods_dir,software):
     """Download installers from HTML page

--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -63,7 +63,10 @@ def download_lessons(ods_dir):
                   "https://datacarpentry.org/sql-ecology-lesson/"]
 
     for lesson in dc_lessons:
-        subprocess.run(["wget", "-r", "-k", "-N", "-c", "--no-parent", "-P", ods_dir, lesson])
+        print(f"Downloading lesson from {lesson}")
+        subprocess.run(["wget", "-r", "-k", "-N", "-c", "--no-parent", "-P", ods_dir, lesson],
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.STDOUT)
 
     sc_lessons = ["http://swcarpentry.github.io/shell-novice",
                   "http://swcarpentry.github.io/git-novice",
@@ -77,7 +80,10 @@ def download_lessons(ods_dir):
 
     # Software Carpentry lessons have external CSS so requires a more expansize search & rewriting to get all necessary files
     for lesson in sc_lessons:
-        subprocess.run(["wget", "-p", "-r", "-k", "-N", "-c", "-E", "-H", "-D", "swcarpentry.github.io", "-K", "--no-parent", "-P", ods_dir, lesson])
+        print(f"Downloading lesson from {lesson}")
+        subprocess.run(["wget", "-p", "-r", "-k", "-N", "-c", "-E", "-H", "-D", "swcarpentry.github.io", "-K", "--no-parent", "-P", ods_dir, lesson],
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.STDOUT)
 
 def download_software(ods_dir,software):
     """Download installers from HTML page


### PR DESCRIPTION
These lessons reference CSS outside of their own directories within the
website, so require spanning across hosts. Thi is limited to the lesson
site to avoid major expansions of the volume of data stored.

This is only done for Software Carpentry because it is not needed for
Data Carpentry and because DC lessons are posted to the organizations
main domain adding -H increases storage by 10x.

Co-authored-by: Virnaliz Cruz <virnaliz.cruz@weecology.org>