### PR TITLE
Fix RStudio download

### DIFF
--- a/offlinedatasci/cli.py
+++ b/offlinedatasci/cli.py
@@ -6,14 +6,15 @@ from offlinedatasci import *
 def get_installer_functions(selection,ods_dir):
     if selection == "all":
         download_r(ods_dir)
-        download_software(ods_dir, "rstudio")
+        download_rstudio(ods_dir)
         download_minicran(ods_dir) 
         download_lessons(ods_dir)
-        download_software(ods_dir,"python")
+        download_python(ods_dir)
         download_python_libraries(ods_dir)
-
-    elif selection == "rstudio" or selection == "python":
-        download_software(ods_dir, selection)
+    elif selection == "rstudio":
+        download_rstudio(ods_dir)
+    elif selection == "python":
+        download_python(ods_dir)
     else:
         try:
             download_function = f"download_{selection}"


### PR DESCRIPTION
RStudio has changed it's download page from a table with different versions to a page with a single link for each OS to the newest version.

Accommodating this change requires separate functions for RStudio & Python downloads, which is more consistent with the overall design as well.