### PR TITLE
Updates and improvements to local PyPI install

### DIFF
--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -220,6 +220,7 @@ def download_python_libraries(ods_dir,py_library_reqs = [ "matplotlib", "noteboo
         'dest': download_dir,
         'pkgs': py_library_reqs,
         'python_version': '3.11',
+        'allow_binary': True
     }
     pypi_mirror.download(platform = ['manylinux_2_17_x86_64'], **parameters)
     pypi_mirror.download(platform = ['macosx_10_12_x86_64'], **parameters)

--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -219,10 +219,10 @@ def download_python_libraries(ods_dir,py_library_reqs = [ "matplotlib", "noteboo
         'pip': 'pip3',
         'dest': download_dir,
         'pkgs': py_library_reqs,
-        'python_version': '3.9.6'
+        'python_version': '3.11',
     }
-    pypi_mirror.download(platform = ['manylinux1_x86_64'], **parameters)
-    pypi_mirror.download(platform = ['macosx_10_10_x86_64'], **parameters)
+    pypi_mirror.download(platform = ['manylinux_2_17_x86_64'], **parameters)
+    pypi_mirror.download(platform = ['macosx_10_12_x86_64'], **parameters)
     pypi_mirror.download(platform = ['win_amd64'], **parameters)
     mirror_creation_parameters = {
         'download_dir': download_dir,

--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -227,7 +227,8 @@ def download_python_libraries(ods_dir,py_library_reqs = [ "matplotlib", "noteboo
     pypi_mirror.download(platform = ['win_amd64'], **parameters)
     mirror_creation_parameters = {
         'download_dir': download_dir,
-        'mirror_dir': pypi_dir
+        'mirror_dir': pypi_dir,
+        'copy': True
     }
     pypi_mirror.create_mirror(**mirror_creation_parameters)
 


### PR DESCRIPTION
* Update to newest Python version and platform naming
* Explicitly allow binary packages
* Copy package files instead of symlinking to support use without web server

Fixes #51 