### PR TITLE
Handle cases where external dependendies are not installed

### DIFF
--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -10,7 +10,9 @@ import subprocess
 import urllib.request, urllib.error, urllib.parse
 import pkg_resources
 import pypi_mirror
+import shutil
 import sys
+import warnings
 
 def download_and_save_installer(latest_version_url, destination_path):
     """Download and save installer in user given path.
@@ -44,6 +46,19 @@ def download_lessons(ods_dir):
     Keyword arguments:
     destination_path -- Path to save rendered HTML lessons
     """
+
+    if not shutil.which('wget'):
+        warnings.warn("""wget not detected so not downloading lessons.
+
+        wget needs to be installed on your computer to clone lesson websites.
+
+        macOS: you can install wget using Xcode command line tools
+               or using `conda install wget -c conda-forge` if you are using conda.
+        
+        Windows: you can download a wget binary from: https://eternallybored.org/misc/wget/
+        """)
+        return
+
     dc_lessons = ["https://datacarpentry.org/ecology-workshop/",
                   "https://datacarpentry.org/spreadsheet-ecology-lesson/",
                   "http://datacarpentry.org/OpenRefine-ecology-lesson/",

--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -215,6 +215,14 @@ def download_minicran(ods_dir,py_library_reqs = ["tidyverse", "RSQLite"]):
     Keyword arguments:
     ods_dir -- Directory to create CRAN mirror
     """
+    if not shutil.which('Rscript'):
+        warnings.warn("""Rscript not detected so not installing miniCRAN.
+
+        R needs to be installed on your computer to clone lesson websites.
+
+        Install R from: https://cran.r-project.org/
+        """)
+        return
     minicranpath = pkg_resources.resource_filename("offlinedatasci", "miniCran.R")
     custom_library_string = ' '.join(py_library_reqs)
     subprocess.run(["Rscript", minicranpath, ods_dir, custom_library_string])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ classifiers = [
 ]
 
 dependencies = [
-  'wget',
   'beautifulsoup4',
   'lxml',
   'python-pypi-mirror',


### PR DESCRIPTION
Warn users about missing external dependencies and don't run instead of throwing an error.

Also remove the wget dependency which is actually pointing to a Python package we aren't using not the real wget.