### PR TITLE
Fix miniCRAN macOS repository creation

### DIFF
--- a/offlinedatasci/miniCran.R
+++ b/offlinedatasci/miniCran.R
@@ -3,12 +3,27 @@ args = commandArgs(trailingOnly = TRUE)
 package_list = strsplit(args[2]," ")[[1]]
 pth = file.path(args[1], "miniCRAN")
 
-repo = c("https://cran.rstudio.com")
+repo = c("https://cloud.r-project.org/")
+
+install_minicran = FALSE
 if (!require("miniCRAN")) {
-  install.packages("miniCRAN")
-  library("miniCRAN")
+    install_minicran = TRUE
+} else if (packageVersion('miniCRAN') <= "0.2.16") {
+    install_minicran = TRUE
 }
-types = c("source", "win.binary", "mac.binary")
+
+# Currently installing from ethanwhite's fork, thus requiring remotes, because the current
+# R release for macOS doesn't work on the released version of miniCRAN
+if (install_minicran) {
+    if (!require("remotes")) {
+        install.packages("remotes")
+    }
+    remotes::install_github("ethanwhite/miniCRAN") 
+}
+
+library(miniCRAN)
+
+types = c("source", "win.binary", "mac.binary.big-sur-x86_64", "mac.binary.big-sur-arm64")
 
 for (type in types) {
     repo_bin_path <- miniCRAN:::repoBinPath(path = pth, type = type, Rversion = R.version)
@@ -21,7 +36,7 @@ for (type in types) {
     DC_pkg_tree = pkgDep(package_list, repos = repo, type = type, suggests = FALSE, Rversion = R.version)
     local_cran_avail = pkgAvail(repos = pth, type = type, Rversion = R.version)[, "Version"]
     pkgs_to_download = DC_pkg_tree[!DC_pkg_tree %in% names(local_cran_avail)]
-    if (length(pkgs_to_download) ==0) {
+    if (length(pkgs_to_download) == 0) {
         cat("Repository already exists, checking updates for", type, "\n")
         updatePackages(path = pth, repos = repo, type = type, ask = FALSE)
     
@@ -31,4 +46,3 @@ for (type in types) {
         makeRepo(pkgs_to_download, path = pth, repos = repo, type = type)
     }
 }
-


### PR DESCRIPTION
miniCRAN has been erroring due to a change in repository structure with the most recent release of R. See #61 for details.

This fixes this by updating the mac binary type(s) to include the version and architecture and by using a fork of miniCRAN with the following change:
https://github.com/ethanwhite/miniCRAN/commit/d56c7da058d27a0fecc9d20f3ae42b8887d62798

Hopefully that change will be merged into miniCRAN soon, at which time we can first install from the main miniCRAN GitHub repo and then (once release) go back to installing from CRAN.

Fixes #61 