### PR TITLE
Add functions for (de)activating local minicran install as repo

### DIFF
--- a/offlinedatasci/cli.py
+++ b/offlinedatasci/cli.py
@@ -29,6 +29,10 @@ def main():
                                 default = 'all',
                                 nargs = '+',
                                 choices=INSTALL_OPTIONS)
+    install_parser.add_argument('path',
+                                 metavar = 'path',
+                                 type = str,
+                                 help = 'path to setup offlinedatasci files in')
 
     packages_parser = subparsers.add_parser('add-packages')
     packages_parser.add_argument('language',
@@ -36,26 +40,39 @@ def main():
                                 choices =['r', 'python'])
     packages_parser.add_argument('libraries',
                                 nargs = '+')
+    packages_parser.add_argument('path',
+                                 metavar = 'path',
+                                 type = str,
+                                 help = 'path to setup offlinedatasci files in')
 
-    parser.add_argument('path',
-                        metavar = 'path',
-                        type = str,
-                        help = 'path to setup offlinedatasci files in') 
-
+    
+    activate_parser = subparsers.add_parser('activate')
+    activate_parser.add_argument('path',
+                                metavar = 'path',
+                                type = str,
+                                help = 'path to offlinedatasci files directory')
+    
+    deactivate_parser = subparsers.add_parser('deactivate')
 
     args = parser.parse_args()
-    ods_dir = get_ods_dir(args.path)
 
     if args.command == 'install':
+        ods_dir = get_ods_dir(args.path)
         for i in args.item:
             get_installer_functions(i, ods_dir)
 
     elif args.command == 'add-packages':
+        ods_dir = get_ods_dir(args.path)
         packages_to_install = package_selection(args.language[0], args.libraries)
         if args.language[0] == "python":
             download_python_libraries(ods_dir, packages_to_install)
         elif args.language[0] == "r":
             download_minicran(ods_dir, packages_to_install)
+    elif args.command == "activate":
+        ods_dir = get_ods_dir(args.path)
+        activate(ods_dir)
+    elif args.command == "deactivate":
+        deactivate()
         
             
 if __name__=='__main__':

--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -47,6 +47,7 @@ def add_lesson_index_page(lesson_path):
 
 def activate(ods_dir):
     activate_cran(ods_dir)
+    activate_pypi(ods_dir)
 
 def activate_cran(ods_dir):
     minicran_path = os.path.join("file://", ods_dir.lstrip("/"), "miniCRAN") #lstrip needed because "If any component is an absolute path, all previous path components will be discarded"
@@ -68,8 +69,39 @@ def activate_cran(ods_dir):
         if not activated:
             output.write(rprofile_line)
 
+def activate_pypi(ods_dir):
+    pypi_path = os.path.join("file:///", ods_dir.lstrip("/"), "pypi") #lstrip needed because "If any component is an absolute path, all previous path components will be discarded"
+    pip_config_line = f"#Added by offlinedatasci\n[global]\nindex-url = {pypi_path}\n"
+    pip_config_folder_path = Path(os.path.join(os.path.expanduser("~"), ".config", "pip"))
+    pip_config_path = Path(pip_config_folder_path, "pip.conf")
+    if not pip_config_folder_path.is_dir():
+        print("\nCreating .config/pip folder in home directory")
+        Path.mkdir(pip_config_folder_path, parents=True)
+    if pip_config_path.is_file():
+        with open(pip_config_path) as input:
+            pip_config_list = list(input)
+    else:
+        pip_config_list = []
+    with open(pip_config_path, 'w') as output:
+        if not pip_config_list:
+            output.write(pip_config_line)
+        else:
+            activated = False
+            for line in pip_config_list:
+                if line.strip() == pip_config_line.strip():
+                    output.write(line)
+                    activated = True
+                elif line.strip() == f"#{pip_config_line.strip()}":
+                    output.write(pip_config_line)
+                    activated = True
+                else:
+                    output.write(line)
+            if not activated:
+                output.write(pip_config_line)
+    
 def deactivate():
     deactivate_cran()
+    deactivate_pypi()
 
 def deactivate_cran():
     rprofile_path = os.path.join(os.path.expanduser("~"), ".Rprofile")
@@ -79,6 +111,25 @@ def deactivate_cran():
         for line in rprofile_list:
             if "#Added by offlinedatasci" in line.strip():
                 pass
+            else:
+                output.write(line)
+
+def deactivate_pypi():
+    pip_config_folder_path = Path(os.path.join(os.path.expanduser("~"), ".config", "pip"))
+    pip_config_path = Path(pip_config_folder_path, "pip.conf")
+    with open(pip_config_path) as input:
+        pip_config_list = list(input)
+    last_line_ods_comment = False
+    next_last_line_ods_comment = False
+    with open(pip_config_path, 'w') as output:
+        for line in pip_config_list:
+            if "#Added by offlinedatasci" in line.strip():
+                last_line_ods_comment = True
+            elif last_line_ods_comment:
+                next_last_line_ods_comment = True
+                last_line_ods_comment = False
+            elif next_last_line_ods_comment:
+                next_last_line_ods_comment = False
             else:
                 output.write(line)
 
@@ -351,7 +402,8 @@ def get_default_packages(language):
     packages = { 
         "r": {
             "data-carpentry": ["tidyverse", "RSQLite"],
-            "data-science": ["dplyr", "ggplot2", "shiny", "lubridate", "knitr", "esquisse", "mlr3", "knitr", "DT"]
+            "data-science": ["dplyr", "ggplot2", "shiny", "lubridate", "knitr",
+                             "esquisse", "mlr3", "knitr", "DT", "ratdat"]
         },
         "python": {
             "data-carpentry": ["pandas", "notebook", "numpy", "matplotlib", "plotnine"], 

--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -46,10 +46,35 @@ def add_lesson_index_page(lesson_path):
         index_file.writelines(str(a))
 
 def activate(ods_dir):
+    """Use local mirrors for CRAN and PyPI repositories
+
+    Parameters:
+    ods_dir (str): The directory where the offline data science (ods) environment is located. 
+                   This directory should contain the miniCRAN and PyPI repositories.
+
+    Modifies the .Rprofile and pip.conf files in the user's home directory to set the CRAN and PyPI 
+    repositories to the local mirrors located in the ods_dir.
+
+    The function does not return any value. It modifies the .Rprofile and pip.conf files in place.
+    """
+        
     activate_cran(ods_dir)
     activate_pypi(ods_dir)
 
 def activate_cran(ods_dir):
+    """Use local mirror of CRAN
+
+    Parameters:
+    ods_dir (str): The directory where the offline data science (ods) environment is located. 
+                   This directory should contain the miniCRAN repository.
+
+    The function works by adding a line to the .Rprofile file that sets the CRAN repository to the miniCRAN repository 
+    located in the ods_dir. If this line already exists in the .Rprofile file, it is not added again. If the line exists 
+    but is commented out, it is uncommented.
+
+    The function does not return any value. It modifies the .Rprofile file in place.
+    """
+
     minicran_path = os.path.join("file://", ods_dir.lstrip("/"), "miniCRAN") #lstrip needed because "If any component is an absolute path, all previous path components will be discarded"
     rprofile_line = 'local({r <- getOption("repos"); r["CRAN"] <- "%s"; options(repos=r)}) #Added by offlinedatasci\n' % minicran_path
     rprofile_path = Path(os.path.join(os.path.expanduser("~"), ".Rprofile"))
@@ -73,6 +98,19 @@ def activate_cran(ods_dir):
             output.write(rprofile_line)
 
 def activate_pypi(ods_dir):
+    """Use local mirror of PyPI
+
+    Parameters:
+    ods_dir (str): The directory where the offline data science (ods) environment is located. 
+                   This directory should contain the PyPI repository in a pypi subdirectory.
+
+    The function works by adding a line to the ~/.config/pip.conf file that sets the index-url to the PyPI repository 
+    located in the ods_dir. If this line already exists in the pip.conf file, it is not added again. If the line is
+    commented out, it is uncommented.
+
+    The function does not return any value. It modifies the pip.conf file in place.
+    """
+
     pypi_path = os.path.join("file:///", ods_dir.lstrip("/"), "pypi") #lstrip needed because "If any component is an absolute path, all previous path components will be discarded"
     pip_config_line = f"#Added by offlinedatasci\n[global]\nindex-url = {pypi_path}\n"
     pip_config_folder_path = Path(os.path.join(os.path.expanduser("~"), ".config", "pip"))
@@ -103,10 +141,18 @@ def activate_pypi(ods_dir):
                 output.write(pip_config_line)
     
 def deactivate():
+    """Stop using the local CRAN and PyPI mirrors
+    
+    Removes any lines added by offlinedatasci to ~/.Rprofile and ~/.config/pip/pip.conf
+    """
     deactivate_cran()
     deactivate_pypi()
 
 def deactivate_cran():
+    """Stop using the local CRAN mirror
+
+    Removes any lines added by offlinedatasci to ~/.Rprofile 
+    """
     rprofile_path = os.path.join(os.path.expanduser("~"), ".Rprofile")
     with open(rprofile_path) as input:
         rprofile_list = list(input)
@@ -118,6 +164,10 @@ def deactivate_cran():
                 output.write(line)
 
 def deactivate_pypi():
+    """Stop using the local PyPI mirror
+
+    Removes any lines added by offlinedatasci to ~/.config/pip/pip.conf 
+    """
     pip_config_folder_path = Path(os.path.join(os.path.expanduser("~"), ".config", "pip"))
     pip_config_path = Path(pip_config_folder_path, "pip.conf")
     with open(pip_config_path) as input:

--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -52,9 +52,12 @@ def activate(ods_dir):
 def activate_cran(ods_dir):
     minicran_path = os.path.join("file://", ods_dir.lstrip("/"), "miniCRAN") #lstrip needed because "If any component is an absolute path, all previous path components will be discarded"
     rprofile_line = 'local({r <- getOption("repos"); r["CRAN"] <- "%s"; options(repos=r)}) #Added by offlinedatasci\n' % minicran_path
-    rprofile_path = os.path.join(os.path.expanduser("~"), ".Rprofile")
-    with open(rprofile_path) as input:
-        rprofile_list = list(input)
+    rprofile_path = Path(os.path.join(os.path.expanduser("~"), ".Rprofile"))
+    if rprofile_path.is_file():
+        with open(rprofile_path) as input:
+            rprofile_list = list(input)
+    else:
+        rprofile_list = []
     with open(rprofile_path, 'w') as output:
         activated = False
         for line in rprofile_list:

--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -45,6 +45,43 @@ def add_lesson_index_page(lesson_path):
     with open(Path(Path(lesson_path), Path("index.html")), "w+") as index_file:
         index_file.writelines(str(a))
 
+def activate(ods_dir):
+    activate_cran(ods_dir)
+
+def activate_cran(ods_dir):
+    minicran_path = os.path.join("file://", ods_dir.lstrip("/"), "miniCRAN") #lstrip needed because "If any component is an absolute path, all previous path components will be discarded"
+    rprofile_line = 'local({r <- getOption("repos"); r["CRAN"] <- "%s"; options(repos=r)}) #Added by offlinedatasci\n' % minicran_path
+    rprofile_path = os.path.join(os.path.expanduser("~"), ".Rprofile")
+    with open(rprofile_path) as input:
+        rprofile_list = list(input)
+    with open(rprofile_path, 'w') as output:
+        activated = False
+        for line in rprofile_list:
+            if line.strip() == rprofile_line.strip():
+                output.write(line)
+                activated = True
+            elif line.strip() == f"#{rprofile_line.strip()}":
+                output.write(rprofile_line)
+                activated = True
+            else:
+                output.write(line)
+        if not activated:
+            output.write(rprofile_line)
+
+def deactivate():
+    deactivate_cran()
+
+def deactivate_cran():
+    rprofile_path = os.path.join(os.path.expanduser("~"), ".Rprofile")
+    with open(rprofile_path) as input:
+        rprofile_list = list(input)
+    with open(rprofile_path, 'w') as output:
+        for line in rprofile_list:
+            if "#Added by offlinedatasci" in line.strip():
+                pass
+            else:
+                output.write(line)
+
 def download_and_save_installer(latest_version_url, destination_path):
     """Download and save installer in user given path.
 

--- a/test/test_offlinedatasci.py
+++ b/test/test_offlinedatasci.py
@@ -1,5 +1,33 @@
-from offlinedatasci import *
+import os
 from glob import glob
+
+from offlinedatasci import *
+
+def test_activate_cran(tmp_path, mocker):
+    ods_dir = str(tmp_path)
+    mocker.patch('os.path.expanduser', return_value=tmp_path)
+    activate_cran(ods_dir)
+    rprofile_path = Path(os.path.join(tmp_path, ".Rprofile"))
+    assert rprofile_path.is_file()
+    
+    # Check the content of the .Rprofile file
+    # with open(rprofile_path) as f:
+    #     lines = f.readlines()
+    #     assert f'#Added by offlinedatasci' in lines
+
+def test_activate_pypi(tmp_path, mocker):
+    ods_dir = str(tmp_path)
+    mocker.patch('os.path.expanduser', return_value=ods_dir)
+    activate_pypi(ods_dir)
+
+    pip_config_folder_path = Path(os.path.join(tmp_path, ".config", "pip"))
+    pip_config_path = Path(pip_config_folder_path, "pip.conf")
+    assert pip_config_path.is_file()
+    
+    with open(pip_config_path) as f:
+        lines = f.readlines()
+        lines = ''.join(lines)
+        assert f"#Added by offlinedatasci\n[global]\nindex-url = file:///{ods_dir.lstrip('/')}/pypi\n" in lines
 
 def test_download_r(tmp_path):
     download_r(tmp_path)


### PR DESCRIPTION
For advanced users installing from a local repo mirror is fairly easy, but for novices and even a lot of experienced coders this would involve learning a lot of details they probably don't care about. For workshops with Raspberry PI style servers this would be handled via instruction, but for folks using `offlinedatasci` locally it might be a bit confusing.

This PR adds the ability to run `offlinedatasci activate /path/to/ods`, which will add lines to both `~/.Rprofile` and `~/.config/pip/pip.conf` that will cause `install.packages()` and `pip install` to use the associated offlinedatasci local mirrors.

`offlinedatasci deactivate` will remove all such lines to return these files to their previous state and behavior to normal.

I'm definitely interested in reviews of this since it's messing with users conf files.

Should we prompt the user to confirm this change? Is it a bad idea in general? Other thoughts?