### PR TITLE
Add a daily cron job to GH Actions

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -3,6 +3,8 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  schedule:
+    - cron: '26 02 * * *'
 
 name: Build Check
 


### PR DESCRIPTION
This will help ensure that we catch upstream breakages quickly (e.g., #106).