### PR TITLE
Let setuptools automatically handle package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,5 @@ requires-python = ">=3.6"
 [project.scripts]
 "offlinedatasci"="offlinedatasci:cli.main"
 
-[tool.setuptools.packages]
-find = {}
-
 [tool.setuptools.package-data]
 "*" = ["miniCran.R"]


### PR DESCRIPTION
setuptools already has a built in system for finding packages. By explicitly finding packages without excludes we are discovery the build directory and producing infinitely nested directories when repeatedly installing from the root directory.

Fixes #119