### PR TITLE
Add GH action to automate removal of waiting label

### DIFF
--- a/.github/workflows/automate-waiting-labels.yml
+++ b/.github/workflows/automate-waiting-labels.yml
@@ -1,0 +1,37 @@
+name: Remove waiting labels after new comment
+# From https://github.com/weecology/DeepForest/blob/main/.github/workflows/automate-waiting-labels.yml
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  issues: write # allow removing label from issue
+  pull-requests: write # allow removing label from PR
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Remove label
+      uses: actions/github-script@v5
+      with:
+        script: |
+          const issueNumber = context.issue.number || context.pull_request.number;
+          const repo = context.repo;
+          const labelToRemove = "Awaiting author contribution";
+
+          const { data: issueLabels } = await github.rest.issues.listLabelsOnIssue({
+            ...repo,
+            issue_number: issueNumber
+          });
+
+          if (issueLabels.find(label => label.name === labelToRemove)) {
+            await github.rest.issues.removeLabel({
+              ...repo,
+              issue_number: issueNumber,
+              name: labelToRemove
+            });
+          }


### PR DESCRIPTION
This action will automatically remove the "Awaiting author contribution" label when a new comment is made on an issue.
This means the label can be applied to an issue where we are waiting to hear back and will automatically be removed
when someone comes back with additional information.