### PR TITLE
Update upload-artifact action

### DIFF
--- a/.github/workflows/render-paper.yml
+++ b/.github/workflows/render-paper.yml
@@ -14,7 +14,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled


### PR DESCRIPTION
The current version was deprecated. Hopefully this will fix the failing render-paper action