### PR TITLE
Add pip3 dependency necessary for pypi-mirror

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   'beautifulsoup4',
   'importlib_resources',
   'lxml',
+  'pip3',
   'python-pypi-mirror>=5.2.1',
   'requests',
   'setuptools'


### PR DESCRIPTION
pypi-mirror doesn't have this as a dependency (because it was written a while ago when everything using pip). This is required to run properly under uv and probably other modern package management / environment systems