### PR TITLE
Fix R and RStudio downloads

### DIFF
--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -260,7 +260,7 @@ def download_r_macosx(r_current_version, ods_dir):
     ods_dir -- Directory to save R installers
     """
     baseurl = "https://cloud.r-project.org/bin/macosx/"
-    download_path_arm64 = baseurl + "big-sur-arm64/base/" + r_current_version + "-arm64.pkg"
+    download_path_arm64 = baseurl + "sonoma-arm64/base/" + r_current_version + "-arm64.pkg"
     destination_path_arm64 = Path(Path(ods_dir), Path("R"), Path(r_current_version + "-arm64.pkg"))
     if not os.path.exists(destination_path_arm64):
         print("****Downloading file: ", destination_path_arm64)

--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -190,14 +190,16 @@ def download_rstudio(ods_dir):
     destination_path = Path(Path(ods_dir), Path("rstudio"))
     if not os.path.isdir(destination_path):
         os.makedirs(destination_path)
-    fp = requests.get(baseurl)
-    web_content = fp.content
-    soup = bs.BeautifulSoup(web_content, 'lxml')
-    links = soup.find_all('a')
-    for link in links:
-        if link.has_attr('href') and (".exe" in link['href'] or ".dmg" in link['href']):
-            url = str(link['href'])
-            download_and_save_installer(url, Path(Path(destination_path), Path(os.path.basename(url))))
+    raw_version = requests.get('https://download1.rstudio.org/current.ver').text.strip()
+    # raw_version looks like "2026.04.0+526.pro2"; URL slug uses "-" instead of "+" with no ".pro*" suffix
+    version = re.sub(r'\.pro\d+$', '', raw_version).replace('+', '-')
+    baseurl = 'https://download1.rstudio.org/electron'
+    urls = [
+        f"{baseurl}/windows/RStudio-{version}.exe",
+        f"{baseurl}/macos/RStudio-{version}.dmg",
+    ]
+    for url in urls:
+        download_and_save_installer(url, Path(destination_path, os.path.basename(url)))
 
 def download_python(ods_dir):
     """Download Python installers


### PR DESCRIPTION
- arm64 for macos is now only on Sonoma
- Posit updated the RStudio Desktop website in a way that broke the old download code