### PR TITLE
Use a raw string for the R version regex

### DIFF
--- a/offlinedatasci/main.py
+++ b/offlinedatasci/main.py
@@ -228,7 +228,7 @@ def find_r_current_version(url):
     Keyword arguments:
     url -- CRAN r-project URL
     """
-    version_regex = "(R\-\d+\.\d+\.\d)+\-(?:x86_64|arm64|win)\.(?:exe|pkg)"
+    version_regex = r"(R\-\d+\.\d+\.\d)+\-(?:x86_64|arm64|win)\.(?:exe|pkg)"
     urlfile = requests.get(url)
     for line in urlfile:
         decoded = line.decode("utf-8") 


### PR DESCRIPTION
## Summary
- define the R installer version regex as a raw string
- avoid Python's invalid-escape `SyntaxWarning` without changing the regular expression

Fixes #168

## Validation
- Not run locally
- Existing baseline: `Build Check` on current `main` already fails on Windows in `test_download_r_packages` (`miniCRAN`); Ubuntu and macOS pass